### PR TITLE
Padding vars not used and cannot be overwritten -> Intended?

### DIFF
--- a/Components/Mixins/Padding.sass
+++ b/Components/Mixins/Padding.sass
@@ -14,16 +14,16 @@
 // Default paddings
 // =====================================
 =pt($value: 1)
-  padding-top: _paddingValueRenderer($value, $sassyMarginVertical)
+  padding-top: _paddingValueRenderer($value, $sassyPaddingVertical)
 
 =pr($value: 1)
-  padding-right: _paddingValueRenderer($value, $sassyMarginHorizontal)
+  padding-right: _paddingValueRenderer($value, $sassyPaddingHorizontal)
 
 =pb($value: 1)
-  padding-bottom: _paddingValueRenderer($value, $sassyMarginVertical)
+  padding-bottom: _paddingValueRenderer($value,$sassyPaddingVertical)
 
 =pl($value: 1)
-  padding-left: _paddingValueRenderer($value, $sassyMarginHorizontal)
+  padding-left: _paddingValueRenderer($value, $sassyPaddingHorizontal)
 
 // Combined paddings
 // =====================================
@@ -40,6 +40,6 @@
 // All paddings
 // =====================================
 =p($value:1)
-  $mv: _paddingValueRenderer($value, $sassyMarginVertical)
-  $mh: _paddingValueRenderer($value, $sassyMarginHorizontal)
+  $mv: _paddingValueRenderer($value, $sassyPaddingVertical)
+  $mh: _paddingValueRenderer($value, $sassyPaddingHorizontal)
   padding: $mv $mh $mv $mh

--- a/Config.sass
+++ b/Config.sass
@@ -62,8 +62,8 @@ $sassyMarginVertical: $sassyMargin !default
 // PADDINGS
 // ==================================================
 $sassyPadding: $sassyMargin / 3 !default
-$sassyPaddingHorizontal: $sassyMarginHorizontal / 3 !default
-$sassyPaddingVertical: $sassyMarginVertical / 3 !default
+$sassyPaddingHorizontal: $sassyPadding !default
+$sassyPaddingVertical: $sassyPadding !default
 
 // SPACERS
 // ==================================================


### PR DESCRIPTION
The padding and Margin are always the same despite the option to overwrite $sassyPadding. 

Don´t know if this is intended or a mistake. 